### PR TITLE
Added windows support

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -12,7 +12,7 @@ try:
     
     def _get_memory(pid):
         process = psutil.Process(pid)
-        return process.get_memory_info()[0]
+        return float((float(process.get_memory_info()[0]) / 1024)) / 1024
 except ImportError:
     import subprocess
     


### PR DESCRIPTION
The [psutil](http://code.google.com/p/psutil) module can be used to make memory_profiler cross platform. This patch does this, falling back to the original subprocess method if psutil is not available.
