### PR TITLE
Use argparse cmd line parser instead of optparse

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -69,9 +69,8 @@ def memory_usage(proc= -1, num= -1, interval=.1):
 
     if str(proc).endswith('.py'):
         filename = _find_script(proc)
-        f = open(filename, 'r')
-        proc = f.read()
-        f.close()
+        with open(filename) as f:
+            proc = f.read()
         # TODO: make sure script's directory is on sys.path
         def f_exec(x, locals):
             # function interface for exec


### PR DESCRIPTION
`optparse` is deprecated, this changes it to `argparse`. Also, there are some other small changes that have been made, such as getting rid of `-o`, `-l`, and `-v`; and making the filename a positional argument.
