### PR TITLE
Revert back to optparse

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -248,18 +248,17 @@ def show_results(prof, stream=None):
             stream.write(template.format(l, mem, inc, line))
 
 if __name__ == '__main__':
-    from argparse import ArgumentParser
-    parser = ArgumentParser(usage=_CMD_USAGE)
-    parser.add_argument('filename', help='The file to profile')
+    from optparse import OptionParser
+    parser = OptionParser(usage=_CMD_USAGE)
 
-    if not sys.argv[1:] or sys.argv[1] in ("--help", "-h"):
+    if not sys.argv[1:]:
         parser.print_help()
         sys.exit(2)
 
-    args = parser.parse_args()
+    (options, args) = parser.parse_args()
 
     prof = LineProfiler()
-    __file__ = _find_script(args.filename)
+    __file__ = _find_script(args[0])
     if sys.version_info[0] < 3:
         import __builtin__
         __builtin__.__dict__['profile'] = prof


### PR DESCRIPTION
This one uses optparse again but with the same ideas from the other commit (b6b93a5d7ef88da3938d02ad37e2c1fc94760e5e). This is so that we can run memory_profiler using Python 2.6.

Also, I wasn't sure about removing the conditional that checks whether `sys.argv` is empty. I did remove the right argument to `or`, though, as help will be output anyway if the person who ran memory_profiler specified the `-h` option.
