### PR TITLE
Add global enable for recursion call

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -179,6 +179,7 @@ class LineProfiler:
         self.code_map = {}
         self.enable_count = 0
         self.max_mem = kw.get('max_mem', None)
+        self.enable_global = kw.get('enable_global', False)
 
     def __call__(self, func):
         self.add_function(func)
@@ -262,7 +263,12 @@ class LineProfiler:
 
     def trace_memory_usage(self, frame, event, arg):
         """Callback for sys.settrace"""
-        if event in ('line', 'return') and frame.f_code in self.code_map:
+        if event in ('line', 'return'):
+            f_code = frame.f_code
+            if self.enable_global and f_code not in self.code_map:
+                self.code_map[f_code] = {}
+            
+            if self.enable_global or f_code in self.code_map:
                 lineno = frame.f_lineno
                 if event == 'return':
                     lineno += 1

--- a/test/test_func.py
+++ b/test/test_func.py
@@ -6,6 +6,26 @@ def test_1():
     for i in range(1000):
         c[i] = 2
 
+from memory_profiler import LineProfiler as MemeryProfiler, show_results
+mp = MemeryProfiler(enable_global=True)
+@mp
+def test_inner_func():
+    c = dict((i, i*2) for i in xrange(10000))
+    
+    def inner_func():
+        inner_c = [1] * 1024 * 1024 * 5
+        return inner_c
+    
+    del c
+    inner_func()
+
+    import os
+    dirs = list(os.walk("."))
+
+
 if __name__ == '__main__':
     test_1()
     test_1()
+
+    test_inner_func()
+    show_results(mp)


### PR DESCRIPTION
Hi fabinp, thank you for powerful module, and I'm make some change for recursion call  profiling.

here is case:

```
def test_inner_func():
    c = dict((i, i*2) for i in xrange(10000))

    def inner_func():
        inner_c = [1] * 1024 * 1024 * 5
        return inner_c

    inner_func()
```

In the `test_inner_func`, I need know profile of every sub call normally. so, i'm add an argument for enable the global switch to do this.

demo:

```
from memory_profiler import LineProfiler as MemeryProfiler, show_results
mp = MemeryProfiler(enable_global=True)
@mp
def test_inner_func():
    c = dict((i, i*2) for i in xrange(10000))

    def inner_func():
        inner_c = [1] * 1024 * 1024 * 5
        return inner_c

    del c
    inner_func()

    import os
    dirs = list(os.walk("."))
```
