### PR TITLE
Increasing the accuracy of logfiles

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -363,8 +363,8 @@ def show_results(prof, stream=None):
                 mem = max(lines_normalized[l])
                 inc = mem - mem_old
                 mem_old = mem
-                mem = '{0:9.2f} MB'.format(mem)
-                inc = '{0:9.2f} MB'.format(inc)
+                mem = '{0:9.6f} MB'.format(mem)
+                inc = '{0:9.6f} MB'.format(inc)
             stream.write(template.format(l, mem, inc, sub_lines[i]))
         stream.write('\n\n')
 


### PR DESCRIPTION
Hi,

We've been using memory_profiler for a tablet game using the Kivy framework, and it's been extremely useful and easy to use. However, with its default resolution of .01 MB the logs were not very useful in catching the small memory leaks we were looking for on mobile devices. I increased the number of digits used when formatting the output strings and it solved our issues. I don't know if this would be useful for other users, but at least a way to choose the accuracy with some kind of flag would be really nice.

Sam
