### PR TITLE
No memory_profiler args is transmitted

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -610,7 +610,7 @@ if __name__ == '__main__':
         sys.exit(2)
 
     (options, args) = parser.parse_args()
-    del sys.argv[0]         # Hide "memory_profiler.py" from argument list
+    sys.argv[:] = args  # Remove every memory_profiler arguments
 
     prof = LineProfiler(max_mem=options.max_mem)
     __file__ = _find_script(args[0])


### PR DESCRIPTION
Invoked script used to received the `memory_profiler` options in `sys.argv` in addition of their own, which made the whole thing more or less unusable with options. 

This was partly fixed in f345720bdd26, and is completely fixed now.
