### PR TITLE
Add some options to memory_usage()

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -139,6 +139,8 @@ def memory_usage(proc=-1, interval=.1, timeout=None, max_usage=False, retval=Fal
     -------
     mem_usage : list of floating-poing values
         memory usage, in MB. It's length is always < timeout / interval
+    ret : return value of the profiled function
+        Only returned if retval is set to True
     """
     
     if not max_usage:
@@ -177,7 +179,7 @@ def memory_usage(proc=-1, interval=.1, timeout=None, max_usage=False, retval=Fal
             % (n_args, len(args)))
 
         child_conn, parent_conn = Pipe()  # this will store Timer's results
-        p = Timer(-1, interval, child_conn,max_usage)
+        p = Timer(os.getpid(), interval, child_conn,max_usage)
         p.start()
         parent_conn.recv()  # wait until we start getting memory
         returned = f(*args, **kw)
@@ -208,9 +210,9 @@ def memory_usage(proc=-1, interval=.1, timeout=None, max_usage=False, retval=Fal
         while counter < max_iter:
             counter += 1
             if not max_usage:
-                ret.append(_get_memory(proc.pid))
+                ret.append(_get_memory(proc))
             else:
-                ret = max([ret,_get_memory(proc.pid)])
+                ret = max([ret,_get_memory(proc)])
             time.sleep(interval)
     return ret
 


### PR DESCRIPTION
I found that I needed to modify the behavior of the profiler to suit my purposes. I've implemented these modifications as kwargs to memory_usage(), and I'm submitting this commit in hope that other people may find them useful.

The **max_usage** parameter modifies the behavior of the function so that it
only keeps track of the peak mem usage over the duration of the
profiling. This is useful for profiling very long running processes.

The **retval** parameter is for profiling Python functions. If set, the
return value of the profiled function will be kept and returned in a
tuple along with the memory usage.

By default, both these parameters are False.
