### PR TITLE
Streaming writes for 'mprof run'

### DIFF
--- a/mprof
+++ b/mprof
@@ -206,12 +206,9 @@ def run_action():
     else:
         p = subprocess.Popen(args)
 
-    mu = mp.memory_usage(proc=p, interval=options.interval, timestamps=True,
-                         include_children=options.include_children)
     with open(mprofile_output, "a") as f:
-        for m, t in mu:
-            f.write("MEM {0:.6f} {1:.4f}".format(m, t) + "\n")
-
+        mp.memory_usage(proc=p, interval=options.interval, timestamps=True,
+                        include_children=options.include_children, stream=f)
 
 
 def add_brackets(xloc, yloc, xshift=0, color="r", label=None):


### PR DESCRIPTION
Memory usage measurement are written to file directly, without waiting
for the monitored process to finish. This has several advantages:
- mprof memory usage is constant (no in-memory storage of measurement)
- allows for some basic on-line monitoring (using 'tail -f' on profile
  file)
- When the child process is killed, every measurement taken so far are
  accessible (which was not the case before)
