### PR TITLE
FIX: make it possible to call memory_usage on functions with anonymous args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,4 @@ test:
 	$(PYTHON) -m memory_profiler test/test_as.py
 	$(PYTHON) -m memory_profiler test/test_global.py
 	$(PYTHON) test/test_import.py
+	$(PYTHON) test/test_memory_usage.py

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -213,14 +213,6 @@ def memory_usage(proc=-1, interval=.1, timeout=None, timestamps=False,
         else:
             raise ValueError
 
-        aspec = inspect.getargspec(f)
-        n_args = len(aspec.args)
-        if aspec.defaults is not None:
-            n_args -= len(aspec.defaults)
-        if n_args != len(args):
-            raise ValueError('Function expects %s value(s) but %s where given'
-                             % (n_args, len(args)))
-
         while True:
             child_conn, parent_conn = Pipe()  # this will store MemTimer's results
             p = MemTimer(os.getpid(), interval, child_conn, timestamps=timestamps,

--- a/test/test_import.py
+++ b/test/test_import.py
@@ -1,5 +1,6 @@
 from memory_profiler import profile
 
+
 @profile
 def my_func():
     a = [1] * (10 ** 6)
@@ -8,4 +9,4 @@ def my_func():
     return a
 
 if __name__ == '__main__':
-	my_func()
+    my_func()

--- a/test/test_memory_usage.py
+++ b/test/test_memory_usage.py
@@ -1,0 +1,15 @@
+from memory_profiler import memory_usage
+
+
+def some_func(*args, **kwargs):
+    return args, kwargs
+
+
+def test_memory_usage():
+    # Check that memory_usage works with functions with star args.
+    mem, ret = memory_usage((some_func, (1, 2), dict(a=1)), retval=True)
+    assert ret[0] == (1, 2)
+    assert ret[1] == dict(a=1)
+
+if __name__ == "__main__":
+    test_memory_usage()


### PR DESCRIPTION
The inspect-based check seem useless and limiting to me.
