### PR TITLE
Profile nested functions

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -400,6 +400,13 @@ class LineProfiler(object):
         f.__dict__.update(getattr(func, '__dict__', {}))
         return f
 
+    def add_code(self, code, toplevel_code=None):
+        if code not in self.code_map:
+            self.code_map[code] = {}
+
+            for subcode in filter(inspect.iscode, code.co_consts):
+                self.add_code(subcode)
+
     def add_function(self, func):
         """ Record line profiling information for the given Python function.
         """
@@ -410,9 +417,8 @@ class LineProfiler(object):
             import warnings
             warnings.warn("Could not extract a code object for the object %r"
                           % func)
-            return
-        if code not in self.code_map:
-            self.code_map[code] = {}
+        else:
+            self.add_code(code)
 
     def wrap_function(self, func):
         """ Wrap a function to profile it.

--- a/test/test_nested.py
+++ b/test/test_nested.py
@@ -1,0 +1,29 @@
+# .. an example with a for loop ..
+
+import time
+
+@profile
+def test_1():
+    a = [1] * (10 ** 6)
+    b = [2] * (2 * 10 ** 7)
+    del b
+
+    def test_2():
+        a = [1] * (10 ** 6)
+        b = [2] * (2 * 10 ** 7)
+        del b
+
+        return a
+
+    return test_2
+
+
+if __name__ == '__main__':
+    profile.enable_by_count()
+
+    test_2 = test_1()
+    time.sleep(1)
+    test_2()
+    time.sleep(1)
+
+    profile.disable_by_count()


### PR DESCRIPTION
This PR achieves pretty much the same as #31, but does that without any flags relying only on the fact that nested functions are constants in parent code.

As of now to make this work in case nested functions are executed outside of their parents one needs to wrap the benchmarked portion with `enable_by_count`/`disable_by_count` calls, because nested functions are not wrapped. This is fixable, but the fix is rather sophisticated, so I'd better post it as a separate PR.
