### PR TITLE
Add include_children parameter when creating MemTimer object for external processes

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -58,7 +58,7 @@ def _get_memory(pid, timestamps=False, include_children=False):
             # continue and try to get this from ps
 
     # .. scary stuff ..
-    elif os.name == 'posix':
+    if os.name == 'posix':
         warnings.warn("psutil module not found. memory_profiler will be slow")
         # ..
         # .. memory usage in MiB ..


### PR DESCRIPTION
Hi, 

With a bit of debugging I found the problem, and a solution for issue #69. It is just a forgotten parameter when creating the object MemTimer when benchmarking external processes. 

Also, I noticed that even if psutil module is found, the `_get_memory` function will calculate the memory twice if `os.name == 'posix'`, which was the case in my Mac OSX. I just put an `elif` there.

I have tested this fix executing memory_usage on functions that create threads (i.e with multiprocessing.Pool), as well as with functions that call external programs that in turn create several threads (i.e subprocess.check_call).

Hope that helps!
