### PR TITLE
remove double import warnings

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -407,7 +407,6 @@ class LineProfiler(object):
             # func_code does not exist in Python3
             code = func.__code__
         except AttributeError:
-            import warnings
             warnings.warn("Could not extract a code object for the object %r"
                           % func)
             return


### PR DESCRIPTION
seems that warnings is already imported at the top level of the module
