### PR TITLE
Replaced psutil methods deprecated on v2.0.0

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -45,10 +45,12 @@ def _get_memory(pid, timestamps=False, include_children=False):
     if has_psutil:
         process = psutil.Process(pid)
         try:
-            mem = process.memory_info()[0] / _TWO_20
+            mem_info = getattr(process, 'memory_info', process.get_memory_info)
+            mem = mem_info()[0] / _TWO_20
             if include_children:
                 for p in process.get_children(recursive=True):
-                    mem += p.memory_info()[0] / _TWO_20
+                    mem_info = getattr(p, 'memory_info', p.get_memory_info)
+                    mem += mem_info()[0] / _TWO_20
             if timestamps:
                 return (mem, time.time())
             else:


### PR DESCRIPTION
- Replaced deprecated psutil.get_memory_info() by
  psutil.memory_info()
