### PR TITLE
More robust tracking of subprocesses for macOS.

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -104,7 +104,7 @@ def _get_child_memory(process, meminfo_attr=None):
     try:
         for child in getattr(process, children_attr)(recursive=True):
             yield getattr(child, meminfo_attr)()[0] / _TWO_20
-    except psutil.NoSuchProcess:
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
         # https://github.com/fabianp/memory_profiler/issues/71
         yield 0.0
 


### PR DESCRIPTION
Ignore psutil.AccessDenied when trying to access children - root cause
is discussed in Issue #71 