### PR TITLE
Fix missing SIGKILL signal and mprof command in Windows

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -17,8 +17,12 @@ import inspect
 import subprocess
 import logging
 import traceback
-from signal import SIGKILL
-
+if sys.platform == "win32":
+    # any value except signal.CTRL_C_EVENT and signal.CTRL_BREAK_EVENT
+    # can be used to kill a process unconditionally in Windows
+    SIGKILL = -1
+else:
+    from signal import SIGKILL
 import psutil
 
 

--- a/mprof.bat
+++ b/mprof.bat
@@ -1,0 +1,2 @@
+@echo off
+python %~dpn0 %*

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 import io
 import re
+import sys
 from setuptools import setup
 
 
@@ -39,6 +40,10 @@ Operating System :: Unix
 
 """
 
+scripts = ['mprof']
+if sys.platform == "win32":
+    scripts.append('mprof.bat')
+
 setup(
     name='memory_profiler',
     description='A module for monitoring memory usage of a python program',
@@ -48,7 +53,7 @@ setup(
     author_email='f@bianp.net',
     url='http://pypi.python.org/pypi/memory_profiler',
     py_modules=['memory_profiler'],
-    scripts=['mprof'],
+    scripts=scripts,
     install_requires=['psutil'],
     classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
     license='BSD'


### PR DESCRIPTION
- SIGKILL doesn't exist in Windows, but according to os.kill [official Python doc](https://docs.python.org/3/library/os.html#os.kill) any value should _cause the process to be unconditionally killed_, for example, -1.
- Simpler version of #158, fixing issues #156 and #75 without code duplication.