### PR TITLE
Fix missing mprof.bat inside tar distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
 include COPYING
+include mprof.bat


### PR DESCRIPTION
Adds mprof.bat to list of distribution files in MANIFEST.in. This file would be missing when creating the source distribution from a non-Windows computer, resulting in an installation error on Windows.

This bug is present in the current pypi 0.48.0 release.