### PR TITLE
Fix time-based memory usage not working in python mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,13 +135,13 @@ of the code that is causing the highest memory usage.
 Adding the `profile` decorator to a function and running the Python
 script with
 
-    mprof run <script>
+    mprof run --python <script>
 
 will record timestamps when entering/leaving the profiled function. Running
 
     mprof plot
 
-afterward will plot the result, making plots (using matplotlib) similar to these:
+afterwards will plot the result, making plots (using matplotlib) similar to these:
 
 .. image:: https://camo.githubusercontent.com/3a584c7cfbae38c9220a755aa21b5ef926c1031d/68747470733a2f2f662e636c6f75642e6769746875622e636f6d2f6173736574732f313930383631382f3836313332302f63623865376337382d663563632d313165322d386531652d3539373237623636663462322e706e67
    :target: https://github.com/scikit-learn/scikit-learn/pull/2248

--- a/mprof
+++ b/mprof
@@ -4,7 +4,6 @@ import glob
 import os
 import os.path as osp
 import sys
-import re
 import copy
 import time
 import math
@@ -538,13 +537,6 @@ such file in the current directory."""
 
 
 if __name__ == "__main__":
-    # Workaround for optparse limitation: insert -- before first negative
-    # number found.
-    negint = re.compile("-[0-9]+")
-    for n, arg in enumerate(sys.argv):
-        if negint.match(arg):
-            sys.argv.insert(n, "--")
-            break
     actions = {"rm": rm_action,
                "clean": clean_action,
                "list": list_action,

--- a/mprof
+++ b/mprof
@@ -216,8 +216,10 @@ def run_action():
             args.python = False
     if args.python:
         print("running as a Python program...")
-        if not program[0].startswith("python"):
-            program.insert(0, sys.executable)
+        print("Note: Remove 'memory_profiler import profile' to measure the "\
+              "timestamps of\nfunctions decorated with @profile\n")
+        # sys.executable is inserted in prev condition (.py and not nopython)
+        # TODO: should --python and --nopython be mutually exclusive?
         cmd_line = get_cmd_line(program)
         program[1:1] = ("-m", "memory_profiler", "--timestamp",
                         "-o", mprofile_output)

--- a/mprof.bat
+++ b/mprof.bat
@@ -1,0 +1,2 @@
+@echo off
+python %~dpn0 %*

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 import io
 import re
+import sys
 from setuptools import setup
 
 
@@ -39,6 +40,10 @@ Operating System :: Unix
 
 """
 
+scripts = ['mprof']
+if sys.platform == "win32":
+    scripts.append('mprof.bat')
+
 setup(
     name='memory_profiler',
     description='A module for monitoring memory usage of a python program',
@@ -48,7 +53,7 @@ setup(
     author_email='f@bianp.net',
     url='http://pypi.python.org/pypi/memory_profiler',
     py_modules=['memory_profiler'],
-    scripts=['mprof'],
+    scripts=scripts,
     install_requires=['psutil'],
     classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
     license='BSD'


### PR DESCRIPTION
Fixes issue #173

I was trying to use this module to profile the memory consumption of a python script but I was not able to record the timestamps when entering/leaving a function decorated with `@profile`. Checking the code I realized the script was being profiled as a generic program (not as a python script). I could force running it as a Python program with:

`mprof run --python <script>`

but that lead to another bug, fixed in this pull request. I have also updated the documentation accordingly and removed some redundant code.

I am not sure if this is how this script was intended to be used, but it was the most straight forward way to fix this issue. It is still unclear to me how the optional args _--python_ and _--nopython_ should be used. At the very least, they look mutually exclusive, something not enforced in the current implementation. When clarified, I could rework this part of the script and the documentation.
