### PR TITLE
Adds wraps decorator to profile, fixes issue #186

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ MANIFEST
 
 # Ignore mprof generated files
 mprofile_*.dat
+
+# virtual environment
+venv/

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,6 @@ test:
 	$(PYTHON) test/test_memory_usage.py
 	$(PYTHON) test/test_precision_import.py
 	$(PYTHON) test/test_exception.py
+
+develop:
+	pip install -e .

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PYTHON ?= python
 test:
 	$(PYTHON) -m memory_profiler test/test_func.py
 	$(PYTHON) -m memory_profiler test/test_loop.py
+	$(PYTHON) -m memory_profiler test/test_mprofile.py
 	$(PYTHON) -m memory_profiler test/test_as.py
 	$(PYTHON) -m memory_profiler test/test_global.py
 	$(PYTHON) -m memory_profiler test/test_precision_command_line.py

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -3,20 +3,22 @@
 # .. we'll use this to pass it to the child script ..
 _CLEAN_GLOBALS = globals().copy()
 
-__version__ = '0.50.0'
+__version__ = '0.53.0'
 
 _CMD_USAGE = "python -m memory_profiler script_file.py"
 
-import time
-import sys
+from functools import wraps
+import inspect
+import linecache
+import logging
 import os
 import pdb
-import warnings
-import linecache
-import inspect
 import subprocess
-import logging
+import sys
+import time
 import traceback
+import warnings
+
 if sys.platform == "win32":
     # any value except signal.CTRL_C_EVENT and signal.CTRL_BREAK_EVENT
     # can be used to kill a process unconditionally in Windows
@@ -1067,6 +1069,7 @@ def profile(func=None, stream=None, precision=1, backend='psutil'):
         if not tracemalloc.is_tracing():
             tracemalloc.start()
     if func is not None:
+        @wraps(func)
         def wrapper(*args, **kwargs):
             prof = LineProfiler(backend=backend)
             val = prof(func)(*args, **kwargs)

--- a/test/test_mprofile.py
+++ b/test/test_mprofile.py
@@ -4,6 +4,7 @@ import time
 
 @profile
 def test1(l):
+    """test1 docstring"""
     a = [1] * l
     time.sleep(1)
     return a
@@ -14,8 +15,22 @@ def test2(l):
     time.sleep(1)
     return b
 
+def test3(l):
+    """test3 docstring"""
+    return l
+
 if __name__ == "__main__":
     l = 100000
     test1(l)
     test2(2 * l)
 
+    # make sure that the function name and docstring are set
+    # by functools.wraps
+    # memory_profile.py def profile func is not None case
+    assert (test1.__name__ == 'test1'), 'function name is incorrect'
+    assert (test1.__doc__ == 'test1 docstring'), 'function docstring is incorrect'
+    # memory_profile.py def profile func is None case
+    profile_maker = profile()
+    profiled_test3 = profile_maker(test3)
+    assert (profiled_test3.__name__ == 'test3'), 'function name is incorrect'
+    assert (profiled_test3.__doc__ == 'test3 docstring'), 'function docstring is incorrect'


### PR DESCRIPTION
PR submitted to fix the issue where the @profile decorator doesn't work on flask routes https://github.com/pythonprofilers/memory_profiler/issues/186

Updates made:
- functools.wraps added to the profile function to fix issue 186
- venv virtual environment folder added to gitignore file
- added 'make develop' command to allow local development of the library
- re-ordered imports in memory_profile.py to be alphabetical
- __version__ updated to '0.53.0'
- adds test of the profiled function's name and docstring