### PR TITLE
Make memory_profiler work with Python 2.7 tracemalloc

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -1123,17 +1123,17 @@ def exec_with_profiler(filename, profiler, backend, passed_args=[]):
     ns = dict(_CLEAN_GLOBALS, profile=profiler)
     _backend = choose_backend(backend)
     sys.argv = [filename] + passed_args
-    if _backend == 'tracemalloc' and has_tracemalloc:
-        tracemalloc.start()
-    if PY2:
-        execfile(filename, ns, ns)
-    else:
-        try:
+    try:
+        if _backend == 'tracemalloc' and has_tracemalloc:
+            tracemalloc.start()
+        if PY2:
+            execfile(filename, ns, ns)
+        else:
             with open(filename) as f:
                 exec(compile(f.read(), filename, 'exec'), ns, ns)
-        finally:
-            if has_tracemalloc and tracemalloc.is_tracing():
-                tracemalloc.stop()
+    finally:
+        if has_tracemalloc and tracemalloc.is_tracing():
+            tracemalloc.stop()
 
 
 def run_module_with_profiler(module, profiler, backend, passed_args=[]):

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -1126,11 +1126,8 @@ def exec_with_profiler(filename, profiler, backend, passed_args=[]):
     try:
         if _backend == 'tracemalloc' and has_tracemalloc:
             tracemalloc.start()
-        if PY2:
-            execfile(filename, ns, ns)
-        else:
-            with open(filename) as f:
-                exec(compile(f.read(), filename, 'exec'), ns, ns)
+        with open(filename) as f:
+            exec(compile(f.read(), filename, 'exec'), ns, ns)
     finally:
         if has_tracemalloc and tracemalloc.is_tracing():
             tracemalloc.stop()

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -48,6 +48,7 @@ _TWO_20 = float(2 ** 20)
 
 if PY2:
     import __builtin__ as builtins
+    from future_builtins import filter
 else:
     import builtins
 
@@ -1122,11 +1123,11 @@ def exec_with_profiler(filename, profiler, backend, passed_args=[]):
     ns = dict(_CLEAN_GLOBALS, profile=profiler)
     _backend = choose_backend(backend)
     sys.argv = [filename] + passed_args
+    if _backend == 'tracemalloc' and has_tracemalloc:
+        tracemalloc.start()
     if PY2:
         execfile(filename, ns, ns)
     else:
-        if _backend == 'tracemalloc' and has_tracemalloc:
-            tracemalloc.start()
         try:
             with open(filename) as f:
                 exec(compile(f.read(), filename, 'exec'), ns, ns)


### PR DESCRIPTION
The tracemalloc module can be made to work on Python 2.7 with [the project providing patches against the Pyithon 2.7 source code](http://pytracemalloc.readthedocs.io/install.html#manual-installation). These two changes make `memory_profiler.py` work with tracemalloc on Python 2.

* Use the iterator version of `filter()`
* Start `tracemalloc` when enabled, regardless of Python version.