### PR TITLE
Fixes #195 "large negative increment values"

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -597,9 +597,7 @@ class CodeMap(dict):
 
         prev_line_value = self[code].get(prev_lineno, None) if prev_lineno else None
         prev_line_memory = prev_line_value[1] if prev_line_value else 0
-        #inc = (memory-prev_line_memory)
-        #print('trace lineno=%(lineno)s prev_lineno=%(prev_lineno)s mem=%(memory)s prev_inc=%(previous_inc)s inc=%(inc)s' % locals())
-        self[code][lineno] = (previous_inc + (memory-prev_line_memory), max(memory, previous_memory))
+        self[code][lineno] = (max(previous_inc, memory-prev_line_memory), max(memory, previous_memory))
 
     def items(self):
         """Iterate on the toplevel code blocks."""

--- a/test/test_tracemalloc.py
+++ b/test/test_tracemalloc.py
@@ -18,8 +18,6 @@ EPSILON = 0.0001
 def test_memory_profiler(test_input, expected):
     mem_prof(test_input)
     inc, dec = parse_mem_prof()
-    assert abs(inc - dec) <= EPSILON, \
-        'inc = {}, dec = {}, err = {}'.format(inc, dec, abs(inc - dec))
     assert abs(inc - expected) <= EPSILON, \
         'inc = {}, size = {}, err = {}'.format(
             inc, expected, abs(inc - expected)


### PR DESCRIPTION
This should fix #195. Increment should reflect the largest increment with respect to the previous line, which is not what the previous code was doing. If run in a for loop, for some reason it was accumulating the increments, which was explaining why some people were seeing large negative increments (https://stackoverflow.com/questions/51077423/strange-negative-value-in-memory-profiler-while-reading-file-python)

I also disabled a test that was assuming that the increment of a function that deletes its temporaries need to be zero, which given the above was a wrong test.

@Juanlu001 : I would appreciate your OK if you have time