### PR TITLE
Optionally propagate the exit code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ test:
 	$(PYTHON) test/test_memory_usage.py
 	$(PYTHON) test/test_precision_import.py
 	$(PYTHON) test/test_exception.py
+	$(PYTHON) test/test_exit_code.py
 
 develop:
 	pip install -e .

--- a/mprof.py
+++ b/mprof.py
@@ -189,8 +189,7 @@ def run_action():
                         help="""Monitors forked processes as well (sum up all process memory)""")
     parser.add_argument("--multiprocess", "-M", dest="multiprocess", action="store_true",
                         help="""Monitors forked processes creating individual plots for each child (disables --python features)""")
-    parser.add_argument("--exit-code", "-E", dest="exit_code", action="store_true",
-                        help="""Propagate the exit code""")
+    parser.add_argument("--exit-code", "-E", dest="exit_code", action="store_true", help="""Propagate the exit code""")
     parser.add_argument("--output", "-o", dest="filename",
                         default="mprofile_%s.dat" % time.strftime("%Y%m%d%H%M%S", time.localtime()),
                         help="""File to store results in, defaults to 'mprofile_<YYYYMMDDhhmmss>.dat' in the current directory,
@@ -203,7 +202,7 @@ This file contains the process memory consumption, in Mb (one value per line).""
                              'Option 4: (--python flag present) "<PYTHON_MODULE> <ARG1> <ARG2>..." - profile python module\n'
                         )
     args = parser.parse_args()
-
+    print(args)
     if len(args.program) == 0:
         print("A program to run must be provided. Use -h for help")
         sys.exit(1)

--- a/mprof.py
+++ b/mprof.py
@@ -6,6 +6,7 @@ import re
 import copy
 import time
 import math
+import logging
 
 from collections import defaultdict
 from argparse import ArgumentParser, ArgumentError, REMAINDER, RawTextHelpFormatter
@@ -25,6 +26,9 @@ Available commands:
 Type mprof <command> --help for usage help on a specific command.
 For example, mprof plot --help will list all plotting options.
 """
+
+logger = logging.getLogger(__name__)
+logging.basicConfig()
 
 
 def print_usage():
@@ -185,6 +189,8 @@ def run_action():
                         help="""Monitors forked processes as well (sum up all process memory)""")
     parser.add_argument("--multiprocess", "-M", dest="multiprocess", action="store_true",
                         help="""Monitors forked processes creating individual plots for each child (disables --python features)""")
+    parser.add_argument("--exit-code", "-E", dest="exit_code", action="store_true",
+                        help="""Propagate the exit code""")
     parser.add_argument("--output", "-o", dest="filename",
                         default="mprofile_%s.dat" % time.strftime("%Y%m%d%H%M%S", time.localtime()),
                         help="""File to store results in, defaults to 'mprofile_<YYYYMMDDhhmmss>.dat' in the current directory,
@@ -235,6 +241,11 @@ This file contains the process memory consumption, in Mb (one value per line).""
         mp.memory_usage(proc=p, interval=args.interval, timestamps=True,
                         include_children=args.include_children,
                         multiprocess=args.multiprocess, stream=f)
+
+    if args.exit_code:
+        if p.returncode != 0:
+            logger.error('Program resulted with a non-zero exit code: %s', p.returncode)
+        sys.exit(p.returncode)
 
 
 def add_brackets(xloc, yloc, xshift=0, color="r", label=None, options=None):

--- a/mprof.py
+++ b/mprof.py
@@ -202,7 +202,7 @@ This file contains the process memory consumption, in Mb (one value per line).""
                              'Option 4: (--python flag present) "<PYTHON_MODULE> <ARG1> <ARG2>..." - profile python module\n'
                         )
     args = parser.parse_args()
-    print(args)
+    
     if len(args.program) == 0:
         print("A program to run must be provided. Use -h for help")
         sys.exit(1)

--- a/test/test_exit_code.py
+++ b/test/test_exit_code.py
@@ -2,6 +2,7 @@ import unittest
 import sys
 import tempfile
 
+
 class TestExitCode(unittest.TestCase):
 
     def setUp(self):
@@ -28,6 +29,14 @@ class TestExitCode(unittest.TestCase):
             sys.argv = ['<ignored>', '--exit-code', tmpfile.name]
             self.assertRaisesRegex(SystemExit, '1', self.run_action)
 
+    def test_no_exit_code_success(self):
+        s = "raise RuntimeError('I am not working nicely')"
+        tmpfile = tempfile.NamedTemporaryFile('w', suffix='.py')
+        with tmpfile as ofile:
+            ofile.write(s)
+            ofile.flush()
+            sys.argv = ['<ignored>', tmpfile.name]
+            self.run_action()
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_exit_code.py
+++ b/test/test_exit_code.py
@@ -1,0 +1,33 @@
+import unittest
+import sys
+import tempfile
+
+class TestExitCode(unittest.TestCase):
+
+    def setUp(self):
+        # to be able to import mprof
+        sys.path.append('.')
+        from mprof import run_action
+        self.run_action = run_action
+
+    def test_exit_code_success(self):
+        s = "1+1"
+        tmpfile = tempfile.NamedTemporaryFile('w', suffix='.py')
+        with tmpfile as ofile:
+            ofile.write(s)
+            ofile.flush()
+            sys.argv = ['<ignored>', '--exit-code', tmpfile.name]
+            self.assertRaisesRegex(SystemExit, '0', self.run_action)
+
+    def test_exit_code_fail(self):
+        s = "raise RuntimeError('I am not working nicely')"
+        tmpfile = tempfile.NamedTemporaryFile('w', suffix='.py')
+        with tmpfile as ofile:
+            ofile.write(s)
+            ofile.flush()
+            sys.argv = ['<ignored>', '--exit-code', tmpfile.name]
+            self.assertRaisesRegex(SystemExit, '1', self.run_action)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_exit_code.py
+++ b/test/test_exit_code.py
@@ -18,7 +18,7 @@ class TestExitCode(unittest.TestCase):
             ofile.write(s)
             ofile.flush()
             sys.argv = ['<ignored>', '--exit-code', tmpfile.name]
-            self.assertRaisesRegex(SystemExit, '0', self.run_action)
+            self.assertRaisesRegexp(SystemExit, '0', self.run_action)
 
     def test_exit_code_fail(self):
         s = "raise RuntimeError('I am not working nicely')"
@@ -27,7 +27,7 @@ class TestExitCode(unittest.TestCase):
             ofile.write(s)
             ofile.flush()
             sys.argv = ['<ignored>', '--exit-code', tmpfile.name]
-            self.assertRaisesRegex(SystemExit, '1', self.run_action)
+            self.assertRaisesRegexp(SystemExit, '1', self.run_action)
 
     def test_no_exit_code_success(self):
         s = "raise RuntimeError('I am not working nicely')"


### PR DESCRIPTION
Hi,

I added an `--exit-code` option which tries to propagate the exit code of the underlying program execution. `mprof` is just silently eating it, causing some unexpected behavior when used in e.g. scripts, containers, ...

It is backward compatible in a way that you need to pass `--exit-code|-E` option in the `run` option.

One disruptive change is that I added logger from the standard `logging` library + added the basicConfig. This is not necessary but IMO is a very good standard in the python world. `print` are not respecting formatters etc., I consider their usage wrong.