### PR TITLE
fix max_iter calc when float is given

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -301,7 +301,7 @@ def memory_usage(proc=-1, interval=.1, timeout=None, timestamps=False,
         ret = -1
 
     if timeout is not None:
-        max_iter = int(timeout / interval)
+        max_iter = int(round(timeout / interval))
     elif isinstance(proc, int):
         # external process and no timeout
         max_iter = 1


### PR DESCRIPTION
`0.6 / 0.2` may be equal `2.9999999999999996`, and then `int(2.9999999999999996)` -> 2.
So, float is guileful.