### PR TITLE
Handle unicode files in a Python 2 and 3 compatible fassion using io.open

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -12,6 +12,7 @@ import inspect
 import linecache
 import logging
 import os
+from io import open
 import pdb
 import subprocess
 import sys
@@ -19,6 +20,7 @@ import time
 import traceback
 import warnings
 import contextlib
+
 
 if sys.platform == "win32":
     # any value except signal.CTRL_C_EVENT and signal.CTRL_BREAK_EVENT

--- a/test/test_unicode.py
+++ b/test/test_unicode.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8  -*-
-# run only for Python 2.xx
 @profile
 def test_unicode(txt):
     # test when unicode is present


### PR DESCRIPTION
Fix for issue raised here https://github.com/pythonprofilers/memory_profiler/issues/244

Makefile tests pass changes are minimal: the only change I introduce is using io.open so memory_profiler can handle unicode files in Python 2 & 3.