### PR TITLE
Add missing install requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     entry_points={
         'console_scripts' : ['mprof = mprof:main'],
     },
-    install_requires=['psutil'],
+    install_requires=['psutil','matplotlib'],
     classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
     license='BSD'
 )


### PR DESCRIPTION
I was doing a proposed flow of `mprof run` and `mprof plot` and it depends on `matplotlib`  The `mprof plot` was executed after simple `matplotlib` install, so there is a dependency on `matplotlib` which should be installed when you pip install the package.