### PR TITLE
link from PyPI to github

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     version=find_version("memory_profiler.py"),
     author='Fabian Pedregosa',
     author_email='f@bianp.net',
-    url='http://pypi.python.org/pypi/memory_profiler',
+    url='https://github.com/pythonprofilers/memory_profiler',
     py_modules=['memory_profiler', 'mprof'],
     entry_points={
         'console_scripts' : ['mprof = mprof:main'],


### PR DESCRIPTION
it's useless using the PyPI project url in setup.py because it's only used on the PyPI page