### PR TITLE
Add guppy backend

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -32,7 +32,7 @@ import dis
 
 try:
     from guppy import hpy
-    guppy_inastalled = True
+    guppy_installed = True
     _hpy = hpy()
 except ImportError:
     guppy_installed = False
@@ -1158,7 +1158,7 @@ def choose_backend(new_backend=None):
         ('psutil', True),
         ('posix', os.name == 'posix'),
         ('tracemalloc', has_tracemalloc),
-        ('guppy', guppy_inastalled),
+        ('guppy', guppy_installed),
     ]
     backends_indices = dict((b[0], i) for i, b in enumerate(all_backends))
 


### PR DESCRIPTION
related to my comment here https://github.com/pythonprofilers/memory_profiler/issues/236#issuecomment-549044946
with implementation of guppy3 we can get the right values.

note this implementation does `self.prevlines[-1] == self.prev_lineno:` for guppy backend only, because repeating `[i for i in range(0, 10000000)]` makes the guppy backend extremely slow. although this may not be ideal or acceptable i thought it's worth sharing the code.

```

@profile
def myfn_py():
    ones = [1] * NBR_ITEMS
    twos = [i + 1 for i in ones]
    return twos


@profile
def myfn_np():
    ones_np = np.ones(NBR_ITEMS)
    twos_np = ones_np+1
    return twos_np


myfn_np()
myfn_py()


python -m memory_profiler --backend guppy prof.py 


Line #    Mem usage    Increment   Line Contents
================================================
    11   14.191 MiB   14.191 MiB   @profile
    12                             def myfn_py():
    13   18.006 MiB    3.815 MiB       ones = [1] * NBR_ITEMS
    14   22.098 MiB    4.091 MiB       twos = [i + 1 for i in ones]
    15                                 return twos


Filename: prof.py

Line #    Mem usage    Increment   Line Contents
================================================
    18   14.189 MiB   14.189 MiB   @profile
    19                             def myfn_np():
    20   18.005 MiB    3.817 MiB       ones_np = np.ones(NBR_ITEMS)
    21   21.820 MiB    3.815 MiB       twos_np = ones_np+1
    22   21.820 MiB    0.000 MiB       return twos_np
```
