### PR TITLE
Pass the value of --include-children to TimeStamper

### DIFF
--- a/mprof.py
+++ b/mprof.py
@@ -230,8 +230,10 @@ This file contains the process memory consumption, in Mb (one value per line).""
         if not program[0].startswith("python"):
             program.insert(0, sys.executable)
         cmd_line = get_cmd_line(program)
-        program[1:1] = ("-m", "memory_profiler", "--timestamp",
-                        "-o", mprofile_output)
+        extra_args = ["-m", "memory_profiler", "--timestamp", "-o", mprofile_output]
+        if args.include_children:
+            extra_args.append("--include-children")
+        program[1:1] = extra_args
         p = subprocess.Popen(program)
     else:
         cmd_line = get_cmd_line(program)


### PR DESCRIPTION
This fixes an issue with FUNC lines reporting lower memory usage than MEM lines.

Before:
![mprof-before](https://user-images.githubusercontent.com/44978184/69153381-ce698880-0ae6-11ea-931b-c943ec0b96c7.png)

After:
![mprof-after](https://user-images.githubusercontent.com/44978184/69153395-d32e3c80-0ae6-11ea-99c6-b41baea32751.png)
