### PR TITLE
Use functools.wraps in profile decorator

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -1130,6 +1130,7 @@ def profile(func=None, stream=None, precision=1, backend='psutil'):
             show_results, stream=stream, precision=precision
         )
         if iscoroutinefunction(func):
+            @wraps(wrapped=func)
             @coroutine
             def wrapper(*args, **kwargs):
                 prof = get_prof()
@@ -1137,6 +1138,7 @@ def profile(func=None, stream=None, precision=1, backend='psutil'):
                 show_results_bound(prof)
                 return val
         else:
+            @wraps(wrapped=func)
             def wrapper(*args, **kwargs):
                 prof = get_prof()
                 val = prof(func)(*args, **kwargs)

--- a/test/test_attributes.py
+++ b/test/test_attributes.py
@@ -1,0 +1,12 @@
+from memory_profiler import profile
+
+
+@profile
+def test_with_profile(arg1):
+    """dummy doc"""
+    return None
+
+
+if __name__ == '__main__':
+    assert test_with_profile.__doc__ == "dummy doc"
+    assert test_with_profile.__name__ == "test_with_profile"


### PR DESCRIPTION
This will prevent unwanted local variable and provide proper doc and name from original function. This is to resolve #299 