### PR TITLE
fix: return result from wrapped coroutine function

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -710,7 +710,8 @@ class LineProfiler(object):
             @coroutine
             def f(*args, **kwargs):
                 with self._count_ctxmgr():
-                    yield from func(*args, **kwargs)
+                    res = yield from func(*args, **kwargs)
+                    return res
         else:
             def f(*args, **kwds):
                 with self._count_ctxmgr():

--- a/test/test_async.py
+++ b/test/test_async.py
@@ -10,8 +10,10 @@ def my_func():
     b = [2] * (2 * 10 ** 7)
     yield from asyncio.sleep(1e-2)
     del b
+    return 42
 
 
 if __name__ == '__main__':
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(my_func())
+    res = loop.run_until_complete(my_func())
+    assert res == 42


### PR DESCRIPTION
Addresses https://github.com/pythonprofilers/memory_profiler/issues/289#issuecomment-804218102.