### PR TITLE
Add capability to switch to PSS and USS for psutil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.vscode
 dist
 build
 MANIFEST

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -159,8 +159,8 @@ def _get_memory(pid, backend, timestamps=False, include_children=False, filename
 
             if not hasattr(meminfo, memory_metric):
                 raise NotImplementedError(
-                    f"Metric `{memory_metric}` not available. For details, see:"
-                    f"https://psutil.readthedocs.io/en/latest/index.html?highlight=memory_info#psutil.Process.memory_full_info")
+                    "Metric `{}` not available. For details, see:".format(memory_metric) +
+                    "https://psutil.readthedocs.io/en/latest/index.html?highlight=memory_info#psutil.Process.memory_full_info")
             mem = getattr(meminfo, memory_metric) / _TWO_20
 
             if include_children:

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -148,7 +148,7 @@ def _get_memory(pid, backend, timestamps=False, include_children=False, filename
 
     def _ps_util_full_tool(memory_metric):
 
-        # .. cross-platform but but requires psutil ..
+        # .. cross-platform but requires psutil > 4.0.0 ..
         process = psutil.Process(pid)
         try:
             if not hasattr(process, 'memory_full_info'):

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -152,7 +152,7 @@ def _get_memory(pid, backend, timestamps=False, include_children=False, filename
         process = psutil.Process(pid)
         try:
             if not hasattr(process, 'memory_full_info'):
-                raise NotImplementedError("Backend `ps_util_pss` requires psutil > 4.0.0")
+                raise NotImplementedError("Backend `psutil_pss` and `psutil_uss` requires psutil > 4.0.0")
 
             meminfo_attr = 'memory_full_info'
             meminfo = getattr(process, meminfo_attr)()

--- a/test/test_psutil_memory_full_info.py
+++ b/test/test_psutil_memory_full_info.py
@@ -98,9 +98,9 @@ def test_multiprocessing_showcase():
         n_jobs = 8
         size = 3000
 
-        print(f"Creating data: {size}x{size} ... ", end="")
+        print("Creating data: {size}x{size} ... ".format(size=size), end="")
         a = np.random.random((size, size))
-        print(f"done ({a.size * a.itemsize / 1024**3:.02f} Gb). ", end="")
+        print("done ({size:.02f} Gb). ".format(size=a.size * a.itemsize / 1024**3), end="")
 
         def subprocess(i):
             aa = a.copy()
@@ -116,21 +116,20 @@ def test_multiprocessing_showcase():
             pass
 
         start = datetime.datetime.now()
-        print(f"Starting processing: n_jobs={n_jobs} ... ", end="")
+        print("Starting processing: n_jobs={n_jobs} ... ".format(n_jobs=n_jobs), end="")
         results = joblib.Parallel(n_jobs=n_jobs)(
             joblib.delayed(subprocess)(i) 
             for i in range(n_jobs))
-        print(f"done ({datetime.datetime.now() - start}). ", end="")
+        print("done ({}). ".format(datetime.datetime.now() - start), end="")
 
         return results
 
     rss = memory_usage(proc=func, max_usage=True, backend="psutil", include_children=True, multiprocess=True)
-    print(f"RSS: {rss:.02f}")
+    print("RSS: {rss:.02f}".format(rss=rss))
     uss = memory_usage(proc=func, max_usage=True, backend="psutil_uss", include_children=True, multiprocess=True)
-    print(f"USS: {uss:.02f}")
+    print("USS: {uss:.02f}".format(uss=uss))
     pss = memory_usage(proc=func, max_usage=True, backend="psutil_pss", include_children=True, multiprocess=True)
-    print(f"PSS: {pss:.02f}")
-    print(f"RSS: {rss:.02f}, USS: {uss:.02f}, PSS: {pss:.02f}")
+    print("PSS: {pss:.02f}".format(pss=pss))
 
 
 if __name__ == "__main__":

--- a/test/test_psutil_memory_full_info.py
+++ b/test/test_psutil_memory_full_info.py
@@ -1,0 +1,140 @@
+from memory_profiler import memory_usage
+
+# size = 50000
+size = 3000
+
+
+def test_simple():
+
+    import numpy as np
+
+    def func():
+        a = np.random.random((size, size))
+        return a
+
+    rss = memory_usage(proc=func, max_usage=True, backend="psutil")
+    uss = memory_usage(proc=func, max_usage=True, backend="psutil_uss")
+    pss = memory_usage(proc=func, max_usage=True, backend="psutil_pss")
+    print(rss, uss, pss)
+
+
+def test_multiprocessing():
+
+    import numpy as np
+    import joblib
+    import time
+
+    def func():
+        n_jobs = 4
+        a = np.random.random((size, size))
+
+        def subprocess(i):
+            time.sleep(2)
+            return a[i,i]
+
+        results = joblib.Parallel(n_jobs=n_jobs)(
+            joblib.delayed(subprocess)(i) 
+            for i in range(n_jobs))
+
+        return results
+
+    rss = memory_usage(proc=func, max_usage=True, backend="psutil", include_children=True, multiprocess=True)
+    uss = memory_usage(proc=func, max_usage=True, backend="psutil_uss", include_children=True, multiprocess=True)
+    pss = memory_usage(proc=func, max_usage=True, backend="psutil_pss", include_children=True, multiprocess=True)
+    print(rss, uss, pss)
+
+
+def test_multiprocessing_write():
+
+    import numpy as np
+    import joblib
+    import time
+
+    def func():
+        n_jobs = 4
+        a = np.random.random((size, size))
+
+        def subprocess(i):
+            aa = a.copy()
+            time.sleep(2)
+            return aa[i,i]
+
+        results = joblib.Parallel(n_jobs=n_jobs)(
+            joblib.delayed(subprocess)(i) 
+            for i in range(n_jobs))
+
+        return results
+
+    rss = memory_usage(proc=func, max_usage=True, backend="psutil", include_children=True, multiprocess=True)
+    uss = memory_usage(proc=func, max_usage=True, backend="psutil_uss", include_children=True, multiprocess=True)
+    pss = memory_usage(proc=func, max_usage=True, backend="psutil_pss", include_children=True, multiprocess=True)
+    print(rss, uss, pss)
+
+
+def test_multiprocessing_showcase():
+
+    import numpy as np
+    import joblib
+    import time
+    import datetime
+
+    def func():
+
+        # n_jobs = 32
+        # size = 25000
+        # Creating data: 25000x25000 ... done (4.66 Gb). Starting processing: n_jobs=32 ... done (0:00:37.581291). RSS: 353024.01
+        # Creating data: 25000x25000 ... done (4.66 Gb). Starting processing: n_jobs=32 ... done (0:00:38.867385). USS: 148608.62
+        # Creating data: 25000x25000 ... done (4.66 Gb). Starting processing: n_jobs=32 ... done (0:00:29.049754). PSS: 169253.91
+
+        # n_jobs = 64
+        # size = 10000
+        # Creating data: 10000x10000 ... done (0.75 Gb). Starting processing: n_jobs=64 ... done (0:00:14.701243). RSS: 111362.79
+        # Creating data: 10000x10000 ... done (0.75 Gb). Starting processing: n_jobs=64 ... done (0:00:15.020202). USS: 56108.69
+        # Creating data: 10000x10000 ... done (0.75 Gb). Starting processing: n_jobs=64 ... done (0:00:15.072918). PSS: 54826.61
+        
+        # Conclusion:
+        # * RSS is overestimating like crazy (I checked the actual memory usage using htop)
+
+        n_jobs = 8
+        size = 3000
+
+        print(f"Creating data: {size}x{size} ... ", end="")
+        a = np.random.random((size, size))
+        print(f"done ({a.size * a.itemsize / 1024**3:.02f} Gb). ", end="")
+
+        def subprocess(i):
+            aa = a.copy()
+            r = aa[1,1]
+            aa = a.copy()
+            time.sleep(10)
+            return r
+            
+            # r = a[1,1]
+            # # time.sleep(10)
+            # return r
+            
+            pass
+
+        start = datetime.datetime.now()
+        print(f"Starting processing: n_jobs={n_jobs} ... ", end="")
+        results = joblib.Parallel(n_jobs=n_jobs)(
+            joblib.delayed(subprocess)(i) 
+            for i in range(n_jobs))
+        print(f"done ({datetime.datetime.now() - start}). ", end="")
+
+        return results
+
+    rss = memory_usage(proc=func, max_usage=True, backend="psutil", include_children=True, multiprocess=True)
+    print(f"RSS: {rss:.02f}")
+    uss = memory_usage(proc=func, max_usage=True, backend="psutil_uss", include_children=True, multiprocess=True)
+    print(f"USS: {uss:.02f}")
+    pss = memory_usage(proc=func, max_usage=True, backend="psutil_pss", include_children=True, multiprocess=True)
+    print(f"PSS: {pss:.02f}")
+    print(f"RSS: {rss:.02f}, USS: {uss:.02f}, PSS: {pss:.02f}")
+
+
+if __name__ == "__main__":
+    test_simple()
+    test_multiprocessing()
+    test_multiprocessing_write()
+    test_multiprocessing_showcase()


### PR DESCRIPTION
Hi all,

I had an issue with `memory_profiler` where profiling a multi-processing scenario based on `joblib` resulted in gross overestimation of memory usage. I am not 100% sure why this is happening but I assume it has something to do with "copy on write" or rather that `joblib` seems to use shared memory for "read-only" data and RSS may not factor that into its estimation. Let me know if you have further insights on this. The corresponding issue is: #312 

Anyway, I tried to solve this by patching `memory_profiler` to allow measuring "USS" or "PSS" (https://psutil.readthedocs.io/en/latest/index.html?highlight=memory_info#psutil.Process.memory_full_info). This is the corresponding pull request allowing to specify new backends, i.e., `"psutil_pss"` and `"psutil_uss"`. I also added some sample code to reproduce the memory usage discrepancy.

This is by no means a perfect pull request but it somewhat extends the functionality of `memory_profiler`. Let me know what you think. 