### PR TITLE
Add backend options to `mprof run`

### DIFF
--- a/mprof.py
+++ b/mprof.py
@@ -214,6 +214,8 @@ def run_action():
                         help="""File to store results in, defaults to 'mprofile_<YYYYMMDDhhmmss>.dat' in the current directory,
 (where <YYYYMMDDhhmmss> is the date-time of the program start).
 This file contains the process memory consumption, in Mb (one value per line).""")
+    parser.add_argument("--backend", dest="backend", choices=["psutil", "psutil_pss", "psutil_uss", "posix", "tracemalloc"],
+                        help="Current supported backends: 'psutil', 'psutil_pss', 'psutil_uss', 'posix', 'tracemalloc'")
     parser.add_argument("program", nargs=REMAINDER,
                         help='Option 1: "<EXECUTABLE> <ARG1> <ARG2>..." - profile executable\n'
                              'Option 2: "<PYTHON_SCRIPT> <ARG1> <ARG2>..." - profile python script\n'
@@ -279,7 +281,7 @@ This file contains the process memory consumption, in Mb (one value per line).""
         f.write("CMDLINE {0}\n".format(cmd_line))
         mp.memory_usage(proc=p, interval=args.interval, timeout=args.timeout, timestamps=True,
                         include_children=args.include_children,
-                        multiprocess=args.multiprocess, stream=f)
+                        multiprocess=args.multiprocess, stream=f, backend=args.backend)
 
     if args.exit_code:
         if p.returncode != 0:

--- a/mprof.py
+++ b/mprof.py
@@ -215,7 +215,8 @@ def run_action():
 (where <YYYYMMDDhhmmss> is the date-time of the program start).
 This file contains the process memory consumption, in Mb (one value per line).""")
     parser.add_argument("--backend", dest="backend", choices=["psutil", "psutil_pss", "psutil_uss", "posix", "tracemalloc"],
-                        help="Current supported backends: 'psutil', 'psutil_pss', 'psutil_uss', 'posix', 'tracemalloc'")
+                        default="psutil",
+                        help="Current supported backends: 'psutil', 'psutil_pss', 'psutil_uss', 'posix', 'tracemalloc'. Defaults to 'psutil'.")
     parser.add_argument("program", nargs=REMAINDER,
                         help='Option 1: "<EXECUTABLE> <ARG1> <ARG2>..." - profile executable\n'
                              'Option 2: "<PYTHON_SCRIPT> <ARG1> <ARG2>..." - profile python script\n'


### PR DESCRIPTION
Adds a new argument `--backend` to `mprof run` that adds options for selecting the memory profiling backend: `psutil`, `psutil_pss`, `psutil_uss`, `posix`, `tracemalloc` — which are the memory backends supported by `memory_profiler.py::memory_usage`. Defaults to `psutil`.