### PR TITLE
Fix UnicodeDecodeError during installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -411,7 +411,7 @@ file ~/.ipython/ipy_user_conf.py to add the following lines::
 Memory tracking backends
 ===============================
 `memory_profiler` supports different memory tracking backends including: 'psutil', 'psutil_pss', 'psutil_uss', 'posix', 'tracemalloc'.
-If no specific backend is specified the default is to use "psutil" which measures RSS aka “Resident Set Size”. 
+If no specific backend is specified the default is to use "psutil" which measures RSS aka "Resident Set Size". 
 In some cases (particularly when tracking child processes) RSS may overestimate memory usage (see `example/example_psutil_memory_full_info.py` for an example).
 For more information on "psutil_pss" (measuring PSS) and "psutil_uss" please refer to:
 https://psutil.readthedocs.io/en/latest/index.html?highlight=memory_info#psutil.Process.memory_full_info 

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -311,7 +311,7 @@ def memory_usage(proc=-1, interval=.1, timeout=None, timestamps=False,
 
     backend : str, optional
         Current supported backends: 'psutil', 'psutil_pss', 'psutil_uss', 'posix', 'tracemalloc'
-        If `backend=None` the default is "psutil" which measures RSS aka “Resident Set Size”. 
+        If `backend=None` the default is "psutil" which measures RSS aka "Resident Set Size". 
         For more information on "psutil_pss" (measuring PSS) and "psutil_uss" please refer to:
         https://psutil.readthedocs.io/en/latest/index.html?highlight=memory_info#psutil.Process.memory_full_info 
 


### PR DESCRIPTION
The files `README.rst` and `memory_profiler.py` contain invalid characters for python to decode when `setup.py` is trying to read them. The quotes in `“Resident Set Size”` are Unicode characters `0xe2809c` and `0xe2809d`, whereas the standard ascii quote is `"` with ascii code `22`. 

Using `pip install memory_profiler --user` will get the cached version `memory_profiler-0.59.0.tar.gz (38 kB)`, which contains the special quotes. `pip` will fail the installation and use a fallback cached version `memory_profiler-0.58.0.tar.gz (36 kB)`. 

The complete error is as follow:
```
Traceback (most recent call last):
  File "D:\share\memory_profiler-master\memory_profiler-master\setup.py", line 33, in <module>
    long_description=open('README.rst').read(),
UnicodeDecodeError: 'cp950' codec can't decode byte 0xe2 in position 14818: illegal multibyte sequence
```
and
```
Traceback (most recent call last):
  File "D:\share\memory_profiler-master\memory_profiler-master\setup.py", line 34, in <module>
    version=find_version("memory_profiler.py"),
  File "D:\share\memory_profiler-master\memory_profiler-master\setup.py", line 8, in find_version
    version_file = f.read()
UnicodeDecodeError: 'cp950' codec can't decode byte 0xe2 in position 10853: illegal multibyte sequence
```

Changing the quotes back to standard ascii fixes the error.

### Environment
OS: `Windows 10`
Python: `3.8.10` and `3.10.0`