### PR TITLE
Fix: Large negative increments

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -680,7 +680,7 @@ class CodeMap(dict):
         occ_count = self[code][lineno][2] + 1 if lineno in self[code] else 1
         self[code][lineno] = (
             previous_inc + (memory - prev_line_memory),
-            max(memory, previous_memory),
+            memory,
             occ_count,
         )
 


### PR DESCRIPTION
Issue #219 

During loops the memory may decrease from one iteration to the next. Storing max(memory, prev_line_memory) can lead to ongoing decrements of the increment value since only the max value is stored and it is used to calculate the change to the increment. This change stores the most recent memory value instead of the max.