### PR TITLE
Store child processes by PID

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -164,7 +164,7 @@ def _get_memory(pid, backend, timestamps=False, include_children=False, filename
             mem = getattr(meminfo, memory_metric) / _TWO_20
 
             if include_children:
-                mem +=  sum([mem for (pid, mem) in _get_child_memory(process, meminfo_attr)])
+                mem +=  sum([mem for (pid, mem) in _get_child_memory(process, meminfo_attr, memory_metric)])
 
             if timestamps:
                 return mem, time.time()

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -15,6 +15,7 @@ import inspect
 import linecache
 import logging
 import os
+import io
 import pdb
 import subprocess
 import sys
@@ -1110,7 +1111,7 @@ class MemoryProfilerMagics(Magics):
             counter += 1
             tmp = memory_usage((_func_exec, (stmt, self.shell.user_ns)),
                                timeout=timeout, interval=interval,
-                               max_usage=True,
+                               max_usage=True, max_iterations=1,
                                include_children=include_children)
             mem_usage.append(tmp)
 
@@ -1246,7 +1247,7 @@ def exec_with_profiler(filename, profiler, backend, passed_args=[]):
     try:
         if _backend == 'tracemalloc' and has_tracemalloc:
             tracemalloc.start()
-        with open(filename, encoding='utf-8') as f:
+        with io.open(filename, encoding='utf-8') as f:
             exec(compile(f.read(), filename, 'exec'), ns, ns)
     finally:
         if has_tracemalloc and tracemalloc.is_tracing():


### PR DESCRIPTION
Very similar to #140 just with fewer modifications, so the only thing that changes is that processes are stored by PID rather than by counting numbers.