### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,10 +138,11 @@ give you any information on which function is executed at a given
 time. Depending on the case, it can be difficult to identify the part
 of the code that is causing the highest memory usage.
 
-Adding the `profile` decorator to a function and running the Python
+Adding the `profile` decorator to a function(ensure no 
+`from memory_profiler import profile` statement) and running the Python
 script with
 
-    mprof run <script>
+    mprof run --python python <script>
 
 will record timestamps when entering/leaving the profiled function. Running
 


### PR DESCRIPTION
There is an easily missed note about removing the import statement and the official README is not well explained. Quite a bit misleading. And executing `mprof run <script>` will not show the execution of the different functions as described. See also https://stackoverflow.com/questions/45549087/python-memory-profiler-plotting/61200561?stw=2#61200561