### PR TITLE
Add Quick Start to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,20 @@ To install from source, download the package, extract and type::
 
     $ pip install .
 
+===========
+Quick Start
+===========
+
+Use `mprof` to generate a full memory usage report of your executable and to plot it.
+
+.. code-block:: bash
+
+    mprof run executable
+    mprof plot
+
+The plot would be something like this:
+
+.. image:: https://i.stack.imgur.com/ixCH4.png
 
 =======
  Usage


### PR DESCRIPTION
Adapted from an answer to "Graphing a process's memory usage" on [Stack Overflow](https://stackoverflow.com/a/62876993/111424).

Memory profiler is exactly the tool I've been looking for. But the Usage section of the README makes it seem so complicated to use that it scared me away!

The Stack Overflow answer gets straight to the point and shows how simple it is to use. I think it deserves to be at the top of the README.