### PR TITLE
Handle multiline command-line args

### DIFF
--- a/mprof.py
+++ b/mprof.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import os.path as osp
+import shlex
 import sys
 import re
 import copy
@@ -175,8 +176,7 @@ def clean_action():
 
 def get_cmd_line(args):
     """Given a set or arguments, compute command-line."""
-    blanks = set(' \t')
-    args = [s if blanks.isdisjoint(s) else "'" + s + "'" for s in args]
+    args = [shlex.quote(s).replace('\n', '\\n') for s in args]
     return ' '.join(args)
 
 def find_first_process(name):


### PR DESCRIPTION
Fix the problem from #210 

The problem occurs when `mprof run <command>` has multi-line arguments:

For example:
```bash
read -r -d '' MESSAGE << EOM            
  hello
  world
EOM

mprof run echo "$MESSAGE"
mprof plot
```
```
Using last profile data.
Traceback (most recent call last):
  File "/home/stepan/mprof-example/venv/bin/mprof", line 8, in <module>
    sys.exit(main())
  File "/home/stepan/mprof-example/venv/lib/python3.8/site-packages/mprof.py", line 905, in main
    actions[get_action()]()
  File "/home/stepan/mprof-example/venv/lib/python3.8/site-packages/mprof.py", line 819, in plot_action
    mprofile = plotter(filename, index=n, timestamps=timestamps, options=args)
  File "/home/stepan/mprof-example/venv/lib/python3.8/site-packages/mprof.py", line 409, in plot_file
    mprofile = read_mprofile_file(filename)
  File "/home/stepan/mprof-example/venv/lib/python3.8/site-packages/mprof.py", line 364, in read_mprofile_file
    field, value = l.split(' ', 1)
ValueError: not enough values to unpack (expected 2, got 1)
```
Version:
```bash
pip show memory-profiler
```
```
Name: memory-profiler
Version: 0.60.0
```