### PR TITLE
from types import coroutine

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -7,9 +7,10 @@ __version__ = '0.60.0'
 
 _CMD_USAGE = "python -m memory_profiler script_file.py"
 
-from asyncio import coroutine, iscoroutinefunction
+from asyncio import iscoroutinefunction
 from contextlib import contextmanager
 from functools import partial, wraps
+from types import coroutine
 import builtins
 import inspect
 import linecache


### PR DESCRIPTION
`coroutine` is no longer available via the `asyncio` module as of Python 3.11.

```python-traceback
$ venv311/bin/python -c 'import memory_profiler'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/altendky//venv311/lib/python3.11/site-packages/memory_profiler.py", line 10, in <module>
    from asyncio import coroutine, iscoroutinefunction
ImportError: cannot import name 'coroutine' from 'asyncio' (/home/altendky/.pyenv/versions/3.11.0rc2/lib/python3.11/asyncio/__init__.py)
```