### PR TITLE
test back to CPython 3.5

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -6,7 +6,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10']
+        python:
+          - major_dot_minor: '3.10'
+            safety: false
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -19,7 +21,7 @@ jobs:
           #
           # CPython -> 3.9.0-alpha - 3.9.X
           # PyPy    -> pypy-3.7
-          python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python), matrix.python))[startsWith(matrix.python, 'pypy')] }}
+          python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python.major_dot_minor), matrix.python.major_dot_minor))[startsWith(matrix.python.major_dot_minor, 'pypy')] }}
           architecture: x64
       - run: pip install --upgrade pip wheel
       - run: pip install bandit black codespell flake8 flake8-2020 flake8-bugbear
@@ -42,7 +44,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python:
+          - major_dot_minor: '3.4'
+            safety: false
+          - major_dot_minor: '3.5'
+            safety: false
+          - major_dot_minor: '3.6'
+            safety: false
+          - major_dot_minor: '3.7'
+            safety: false
+          - major_dot_minor: '3.8'
+            safety: true
+          - major_dot_minor: '3.9'
+            safety: true
+          - major_dot_minor: '3.10'
+            safety: true
+          - major_dot_minor: '3.11'
+            safety: true
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -55,12 +73,12 @@ jobs:
           #
           # CPython -> 3.9.0-alpha - 3.9.X
           # PyPy    -> pypy-3.7
-          python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python), matrix.python))[startsWith(matrix.python, 'pypy')] }}
+          python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python.major_dot_minor), matrix.python.major_dot_minor))[startsWith(matrix.python.major_dot_minor, 'pypy')] }}
           architecture: x64
       - run: pip install --upgrade pip wheel
       - run: pip install pytest safety
       - run: pip install --editable .
       - run: pip install numpy pylab-sdk
       - run: make test
-      - if: matrix.python != '3.7'
+      - if: matrix.python.safety
         run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -45,8 +45,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - major_dot_minor: '3.4'
-            safety: false
           - major_dot_minor: '3.5'
             safety: false
           - major_dot_minor: '3.6'

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
 py_modules =
     memory_profiler
     mprof
-python_requires = >=3.4
+python_requires = >=3.5
 install_requires = psutil
 
 [options.entry_points]

--- a/test/test_async.py
+++ b/test/test_async.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 
 from memory_profiler import profile
 
@@ -14,5 +15,13 @@ async def main():
     task = asyncio.create_task(my_func())
     res = await asyncio.gather(task)
 
+async def main_legacy():
+    future = asyncio.ensure_future(my_func())
+    res = await asyncio.gather(future)
+
 if __name__ == '__main__':
-    asyncio.run(main())  # main loop
+    if sys.version_info >= (3, 7):
+        asyncio.run(main())  # main loop
+    else:
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(main_legacy())


### PR DESCRIPTION
Otherwise we can shift the minimum to 3.7 and leave out the workarounds in the async test.  Up to you.