### PR TITLE
handle exception for `psutil.NoSuchProcess` along with `psutil.AccessDenied`

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -144,7 +144,7 @@ def _get_memory(pid, backend, timestamps=False, include_children=False, filename
                 return mem, time.time()
             else:
                 return mem
-        except psutil.AccessDenied:
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
             pass
             # continue and try to get this from ps
 


### PR DESCRIPTION
Hi. I've noticed that there can be a condition where process will be killed between https://github.com/pythonprofilers/memory_profiler/blob/025929f8e4f4ea8c27ddb5ef72fc91f6bd703ea5/memory_profiler.py#L134 and https://github.com/pythonprofilers/memory_profiler/blob/025929f8e4f4ea8c27ddb5ef72fc91f6bd703ea5/memory_profiler.py#L140

In this case, we get an exception  `psutil.NoSuchProcess: process no longer exists (pid=...)`, that we have to handle the same way as it's done here: https://github.com/pythonprofilers/memory_profiler/blob/025929f8e4f4ea8c27ddb5ef72fc91f6bd703ea5/memory_profiler.py#L112